### PR TITLE
Fixed get_send_to error - TOOL-564

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
-Version 1.0.0: Initial Release
-Version 1.0.1: Removed register call in plugin.py to avoid duplicate plugin in
-    sentry admin interface
+Version 1.0.4: Fixed bug caused by get_send_to returning email addresses 
+    instead of user IDs - replaced calls to it with directly looking up the
+    'email' option of the plugin.
+Version 1.0.3: Fixed last line of plugin.py to account for name change
 Version 1.0.2: Renamed from Sentry Mailer to Sentry Custom Mailer, changed from 
     copying Sentry Mail to inheriting it, cleaning up and licensing
+Version 1.0.1: Removed register call in plugin.py to avoid duplicate plugin in
+    sentry admin interface
+Version 1.0.0: Initial Release

--- a/sentry_custom_mailer/plugin.py
+++ b/sentry_custom_mailer/plugin.py
@@ -12,10 +12,14 @@ import logging
 
 from django.conf import settings
 from django.utils.encoding import force_text
-from sentry.plugins.sentry_mail.models import MailPlugin
+from django.core.urlresolvers import reverse
 from django import forms
 from multi_email_field.forms import MultiEmailField, MultiEmailWidget
-from sentry.utils.email import MessageBuilder
+
+from sentry.plugins.sentry_mail.models import MailPlugin
+from sentry.models import Activity, UserOption, Release
+from sentry.utils.http import absolute_uri
+from sentry.utils.email import MessageBuilder, group_id_to_email
 
 import sentry_custom_mailer
 
@@ -50,13 +54,6 @@ class CustomMailerPlugin(MailPlugin):
     project_conf_form = AddEmailForm
     subject_prefix = settings.EMAIL_SUBJECT_PREFIX
 
-    def get_send_to(self, project=None):
-        """
-        Returns a list of email addresses for the users that should be
-        notified of alerts, based on the plugin configuration. 
-        """
-        return self.get_option('emails', project) or []
-
     def _build_message(self, subject, template=None, html_template=None,
                        body=None, project=None, group=None, headers=None,
                        context=None):
@@ -65,7 +62,8 @@ class CustomMailerPlugin(MailPlugin):
         Team, except for the send_to list that is received is assigned to
         the message's list instead of appended. 
         """
-        send_to = self.get_send_to(project)
+
+        send_to = self.get_option('emails', project) or []
         if not send_to:
             logger.debug('Skipping message rendering, no users to send to.')
             return
@@ -84,10 +82,111 @@ class CustomMailerPlugin(MailPlugin):
             context=context,
             reference=group,
         )
-
         msg._send_to = set(send_to)
 
         return msg
+
+    def notify_about_activity(self, activity):
+        if activity.type not in \
+                (Activity.NOTE, Activity.ASSIGNED, Activity.RELEASE):
+            return
+
+        candidate_ids = set(self.get_send_to(activity.project))
+        # Never send a notification to the user that performed the action.
+        candidate_ids.discard(activity.user_id)
+
+        if activity.type == Activity.ASSIGNED:
+            # Only notify the assignee, and only if they are in the candidate set.
+            recipient_ids = candidate_ids & \
+                    set(map(int, (activity.data['assignee'],)))
+        elif activity.type == Activity.NOTE:
+            recipient_ids = candidate_ids - set(
+                UserOption.objects.filter(
+                    user__in=candidate_ids,
+                    key='subscribe_notes',
+                    value=u'0',
+                ).values_list('user', flat=True)
+            )
+        else:
+            recipient_ids = candidate_ids
+
+        if not recipient_ids:
+            return
+
+        project = activity.project
+        org = project.organization
+        group = activity.group
+
+        headers = {}
+
+        context = {
+            'data': activity.data,
+            'author': activity.user,
+            'project': project,
+            'project_link': absolute_uri(reverse('sentry-stream', kwargs={
+                'organization_slug': org.slug,
+                'project_id': project.slug,
+            })),
+        }
+
+        if group:
+            group_link = absolute_uri('/{}/{}/issues/{}/'.format(
+                org.slug, project.slug, group.id
+            ))
+            activity_link = '{}activity/'.format(group_link)
+
+            headers.update({
+                'X-Sentry-Reply-To': group_id_to_email(group.id),
+            })
+
+            context.update({
+                'group': group,
+                'link': group_link,
+                'activity_link': activity_link,
+            })
+
+        # TODO(dcramer): abstract each activity email into its own helper class
+        if activity.type == Activity.RELEASE:
+            context.update({
+                'release': Release.objects.get(
+                    version=activity.data['version'],
+                    project=project,
+                ),
+                'release_link': absolute_uri('/{}/{}/releases/{}/'.format(
+                    org.slug,
+                    project.slug,
+                    activity.data['version'],
+                )),
+            })
+
+        template_name = activity.get_type_display()
+
+        # TODO: Everything below should instead use `_send_mail` for consistency.
+        subject_prefix = project.get_option(
+                'subject_prefix', settings.EMAIL_SUBJECT_PREFIX)
+        if subject_prefix:
+            subject_prefix = subject_prefix.rstrip() + ' '
+
+        if group:
+            subject = '%s%s' % (subject_prefix, group.get_email_subject())
+        elif activity.type == Activity.RELEASE:
+            subject = '%sRelease %s' % \
+                    (subject_prefix, activity.data['version'])
+        else:
+            raise NotImplementedError
+
+        msg = MessageBuilder(
+            subject=subject,
+            context=context,
+            template='sentry/emails/activity/{}.txt'.format(template_name),
+            html_template='sentry/emails/activity/{}.html'.format(template_name),
+            headers=headers,
+            reference=activity,
+            reply_reference=group,
+        )
+	recipients = self.get_option('emails', project) or []
+        msg._send_to.update(recipients)
+        msg.send()
 
 # Legacy compatibility
 MailProcessor = CustomMailerPlugin

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_requires = ['django', 'django-multi-email-field', 'sentry']
 
 setup(
     name='sentry-custom-mailer',
-    version='1.0.3',
+    version='1.0.4',
     author="Kieran Broekhoven",
     author_email="kbroekhoven@clearpathrobotics.com",
     description="A sentry plugin to specify recipients of notification emails",


### PR DESCRIPTION
`get_send_to` does not return email addresses, as its documentation would suggest. Therefore, the original implementation of just changing which email addresses it returned, had to be changed. 

Now, the custom mailer overrides the functions that dictate which email addresses receive notifications (`notify_about_activity` and `_build_message`), leaving `get_send_to` untouched. 
